### PR TITLE
Fix shape mismatch when sampling from wan2.2 i2v.

### DIFF
--- a/extensions_built_in/diffusion_models/wan22/wan22_pipeline.py
+++ b/extensions_built_in/diffusion_models/wan22/wan22_pipeline.py
@@ -262,6 +262,10 @@ class Wan22Pipeline(WanPipeline):
                     noise_pred = noise_uncond + current_guidance_scale * \
                         (noise_pred - noise_uncond)
 
+                if conditioning is not None:
+                    # keep only the part corresponding to the 16 latent channels
+                    noise_pred = noise_pred[:, :latents.shape[1], ...]
+
                 # compute the previous noisy sample x_t -> x_t-1
                 latents = self.scheduler.step(
                     noise_pred, t, latents, return_dict=False)[0]


### PR DESCRIPTION
Wan 2.2 i2v is broken when sampling because of shape mismatch.