### PR TITLE
Import k-diffusion lazily

### DIFF
--- a/toolkit/pipelines.py
+++ b/toolkit/pipelines.py
@@ -12,8 +12,6 @@ from diffusers.pipelines.stable_diffusion import StableDiffusionPipelineOutput
 from diffusers.pipelines.stable_diffusion_xl.pipeline_output import StableDiffusionXLPipelineOutput
 from diffusers.pipelines.stable_diffusion_xl.pipeline_stable_diffusion_xl import rescale_noise_cfg
 from diffusers.utils import is_torch_xla_available
-from k_diffusion.external import CompVisVDenoiser, CompVisDenoiser
-from k_diffusion.sampling import get_sigmas_karras, BrownianTreeNoiseSampler
 from toolkit.models.flux import bypass_flux_guidance, restore_flux_guidance
 from diffusers.image_processor import PipelineImageInput
 from PIL import Image
@@ -213,6 +211,8 @@ class StableDiffusionKDiffusionXLPipeline(StableDiffusionXLPipeline):
         if use_karras_sigmas:
             sigma_min: float = self.k_diffusion_model.sigmas[0].item()
             sigma_max: float = self.k_diffusion_model.sigmas[-1].item()
+            from k_diffusion.sampling import get_sigmas_karras
+
             sigmas = get_sigmas_karras(n=num_inference_steps, sigma_min=sigma_min, sigma_max=sigma_max)
             sigmas = sigmas.to(device)
         else:
@@ -272,6 +272,8 @@ class StableDiffusionKDiffusionXLPipeline(StableDiffusionXLPipeline):
 
         if "noise_sampler" in inspect.signature(self.sampler).parameters:
             min_sigma, max_sigma = sigmas[sigmas > 0].min(), sigmas.max()
+            from k_diffusion.sampling import BrownianTreeNoiseSampler
+
             noise_sampler = BrownianTreeNoiseSampler(latents, min_sigma, max_sigma, noise_sampler_seed)
             sampler_kwargs["noise_sampler"] = noise_sampler
 

--- a/toolkit/sampler.py
+++ b/toolkit/sampler.py
@@ -20,7 +20,6 @@ from toolkit.samplers.mean_flow_scheduler import MeanFlowScheduler
 
 from toolkit.samplers.custom_flowmatch_sampler import CustomFlowMatchEulerDiscreteScheduler
 
-from k_diffusion.external import CompVisDenoiser
 
 from toolkit.samplers.custom_lcm_scheduler import CustomLCMScheduler
 
@@ -185,29 +184,3 @@ def get_sampler(
     scheduler = scheduler_cls.from_config(config)
 
     return scheduler
-
-
-# testing
-if __name__ == "__main__":
-    from diffusers import DiffusionPipeline
-
-    from diffusers import StableDiffusionKDiffusionPipeline
-    import torch
-    import os
-
-    inference_steps = 25
-
-    pipe = StableDiffusionKDiffusionPipeline.from_pretrained("stabilityai/stable-diffusion-2-1-base")
-    pipe = pipe.to("cuda")
-
-    k_diffusion_model = CompVisDenoiser(model)
-
-    pipe = DiffusionPipeline.from_pretrained("CompVis/stable-diffusion-v1-4", custom_pipeline="sd_text2img_k_diffusion")
-    pipe = pipe.to("cuda")
-
-    prompt = "an astronaut riding a horse on mars"
-    pipe.set_scheduler("sample_heun")
-    generator = torch.Generator(device="cuda").manual_seed(seed)
-    image = pipe(prompt, generator=generator, num_inference_steps=20).images[0]
-
-    image.save("./astronaut_heun_k_diffusion.png")


### PR DESCRIPTION
The training image is moving to numpy 2. K diffusion pins <2 and we don't need k diffusion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized dependency loading to improve startup performance by converting module-level imports to lazy loading where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->