### PR TITLE
Log peak VRAM in training metrics

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -2459,6 +2459,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
                             # log to Oxen if enabled
                             if self.oxen_logger and self.oxen_config.enabled:
                                 try:
+                                    # Peak since the last logged row, so the column graphs memory over time
+                                    peak_mem_gb = 0.0
+                                    if torch.cuda.is_available():
+                                        peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9
                                     # Prepare metrics for Oxen
                                     oxen_metrics = {
                                         'step': self.step_num,
@@ -2466,9 +2470,13 @@ class BaseSDTrainProcess(BaseTrainProcess):
                                         'timestamp': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                                         'loss': loss_dict.get('loss', 0.0),
                                         'epoch': self.step_num / len(self.data_loader.dataset) if self.data_loader and hasattr(self.data_loader, 'dataset') else 0.0,
+                                        'peak_mem_gb': peak_mem_gb,
                                     }
 
                                     self.oxen_logger.log_metrics(oxen_metrics, self.step_num)
+                                    # Reset only after a row records the window's peak
+                                    if torch.cuda.is_available():
+                                        torch.cuda.reset_peak_memory_stats()
                                 except Exception as e:
                                     print_acc(f"Warning: Failed to log metrics to Oxen: {e}")
                     elif self.logging_config.log_every is None:
@@ -2485,6 +2493,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
                             # log to Oxen if enabled (every step)
                             if self.oxen_logger and self.oxen_config.enabled:
                                 try:
+                                    # Peak since the last logged row, so the column graphs memory over time
+                                    peak_mem_gb = 0.0
+                                    if torch.cuda.is_available():
+                                        peak_mem_gb = torch.cuda.max_memory_allocated() / 1e9
                                     # Prepare metrics for Oxen
                                     oxen_metrics = {
                                         'step': self.step_num,
@@ -2492,9 +2504,13 @@ class BaseSDTrainProcess(BaseTrainProcess):
                                         'timestamp': datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                                         'loss': loss_dict.get('loss', 0.0),
                                         'epoch': self.step_num / len(self.data_loader.dataset) if self.data_loader and hasattr(self.data_loader, 'dataset') else 0.0,
+                                        'peak_mem_gb': peak_mem_gb,
                                     }
 
                                     self.oxen_logger.log_metrics(oxen_metrics, self.step_num)
+                                    # Reset only after a row records the window's peak
+                                    if torch.cuda.is_available():
+                                        torch.cuda.reset_peak_memory_stats()
                                 except Exception as e:
                                     print_acc(f"Warning: Failed to log metrics to Oxen: {e}")
 

--- a/toolkit/oxen_logger.py
+++ b/toolkit/oxen_logger.py
@@ -108,6 +108,7 @@ class AIToolkitOxenLogger:
                 "loss": 0.0,
                 "learning_rate": 0.0,
                 "epoch": 0,
+                "peak_mem_gb": 0.0,
                 "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             }
 


### PR DESCRIPTION
Training metrics here log loss and learning rate but not GPU memory. Adds peak VRAM to each logged row so memory usage graphs alongside the rest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added peak memory usage tracking to training metrics, so logged runs now include memory peak information alongside loss, learning rate, and epoch.
  * Initial training metrics records now start with a peak memory value for consistency.

* **Bug Fixes**
  * Reset peak GPU memory statistics after logging to keep memory measurements accurate across training steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->