### PR TITLE
Add AGENTS.md with branch conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# ai-toolkit
+
+Fork of Ostris's ai-toolkit. `main` is identical to upstream at all times; our work never lands there. `gs/oxen-experiment-tracker` is our main: branch from it and open PRs against it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+# ai-toolkit
+
+Fork of Ostris's ai-toolkit. `main` is identical to upstream at all times; our work never lands there. `gs/oxen-experiment-tracker` is our main: branch from it and open PRs against it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,1 @@
-# ai-toolkit
-
-Fork of Ostris's ai-toolkit. `main` is identical to upstream at all times; our work never lands there. `gs/oxen-experiment-tracker` is our main: branch from it and open PRs against it.
+AGENTS.md


### PR DESCRIPTION
Tells agents to use gs/oxen-experiment-tracker instead of main, which in my experience is a common source of confusion.

Adds an AGENTS.md noting that gs/oxen-experiment-tracker is our main, with CLAUDE.md symlinked to it.