### PR TITLE
Log VRAM time series during sampling

### DIFF
--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -78,12 +78,13 @@ from toolkit.util.get_model import get_model_class
 # Import Oxen integration (with try/except for optional dependency)
 try:
     from toolkit.oxen_experiment import AIToolkitOxenExperiment
-    from toolkit.oxen_logger import AIToolkitOxenLogger
+    from toolkit.oxen_logger import AIToolkitOxenLogger, SampleMemoryMonitor
     OXEN_AVAILABLE = True
 except ImportError:
     OXEN_AVAILABLE = False
     AIToolkitOxenExperiment = None
     AIToolkitOxenLogger = None
+    SampleMemoryMonitor = None
 
 def flush():
     torch.cuda.empty_cache()
@@ -145,6 +146,8 @@ class BaseSDTrainProcess(BaseTrainProcess):
         self.oxen_config = OxenConfig(**self.get_conf('oxen', {}))
         self.oxen_experiment = None
         self.oxen_logger = None
+        self._sample_round = 0
+        self._sample_mem_monitor = None
 
         self.optimizer: torch.optim.Optimizer = None
         self.lr_scheduler = None
@@ -387,9 +390,23 @@ class BaseSDTrainProcess(BaseTrainProcess):
         # let adapter know we are sampling
         if self.adapter is not None and isinstance(self.adapter, CustomAdapter):
             self.adapter.is_sampling = True
-        
-        # send to be generated
-        self.sd.generate_images(gen_img_config_list, sampler=sample_config.sampler)
+
+        # Record a VRAM time series across this sampling round. The monitor only
+        # reads allocator counters on a side thread (no GPU memory, no sync); the
+        # per-image hook tags each tick with the sample being rendered.
+        if SampleMemoryMonitor is not None and self.oxen_logger and self.oxen_config.enabled:
+            mem_monitor = SampleMemoryMonitor(sample_round=self._sample_round)
+            mem_monitor.set_index(0)
+            self._sample_mem_monitor = mem_monitor
+            try:
+                with mem_monitor:
+                    self.sd.generate_images(gen_img_config_list, sampler=sample_config.sampler)
+            finally:
+                self._sample_mem_monitor = None
+            self._sample_round += 1
+        else:
+            mem_monitor = None
+            self.sd.generate_images(gen_img_config_list, sampler=sample_config.sampler)
 
         
         if self.adapter is not None and isinstance(self.adapter, CustomAdapter):
@@ -403,6 +420,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
             try:
                 sample_dir = os.path.join(self.save_root, "samples")
                 self.oxen_logger.add_samples(sample_dir)
+                if mem_monitor is not None:
+                    self.oxen_logger.log_sample_series(
+                        mem_monitor.samples, self._sample_round - 1, step if step is not None else self.step_num
+                    )
             except Exception as e:
                 print_acc(f"Warning: Failed to save sample images to Oxen: {e}")
         
@@ -761,7 +782,10 @@ class BaseSDTrainProcess(BaseTrainProcess):
         self.prepare_accelerator()
         
     def sample_step_hook(self, img_num, total_imgs):
-        pass
+        # img_num is the 0-based index of the image just finished; point the
+        # memory monitor at the next one so its ticks carry the right index.
+        if self._sample_mem_monitor is not None:
+            self._sample_mem_monitor.set_index(img_num + 1)
     
     def prepare_accelerator(self):
         # set some config

--- a/jobs/process/BaseSDTrainProcess.py
+++ b/jobs/process/BaseSDTrainProcess.py
@@ -394,19 +394,29 @@ class BaseSDTrainProcess(BaseTrainProcess):
         # Record a VRAM time series across this sampling round. The monitor only
         # reads allocator counters on a side thread (no GPU memory, no sync); the
         # per-image hook tags each tick with the sample being rendered.
+        mem_monitor = None
         if SampleMemoryMonitor is not None and self.oxen_logger and self.oxen_config.enabled:
             mem_monitor = SampleMemoryMonitor(sample_round=self._sample_round)
             mem_monitor.set_index(0)
             self._sample_mem_monitor = mem_monitor
-            try:
+        try:
+            if mem_monitor is not None:
                 with mem_monitor:
                     self.sd.generate_images(gen_img_config_list, sampler=sample_config.sampler)
-            finally:
-                self._sample_mem_monitor = None
+            else:
+                self.sd.generate_images(gen_img_config_list, sampler=sample_config.sampler)
+        finally:
+            self._sample_mem_monitor = None
+            # Sampling spikes the shared CUDA peak counter; clear it so the next
+            # training row's peak_mem_gb reflects training, not this sample. Runs
+            # even if generation failed, so a partial spike can't leak either.
+            try:
+                if torch.cuda.is_available():
+                    torch.cuda.reset_peak_memory_stats()
+            except Exception:
+                pass
+        if mem_monitor is not None:
             self._sample_round += 1
-        else:
-            mem_monitor = None
-            self.sd.generate_images(gen_img_config_list, sampler=sample_config.sampler)
 
         
         if self.adapter is not None and isinstance(self.adapter, CustomAdapter):

--- a/toolkit/oxen_logger.py
+++ b/toolkit/oxen_logger.py
@@ -33,6 +33,78 @@ def monitor_train_status(url: str, want_stop_event: threading.Event, finished_ev
 
         finished_event.wait(timeout=10)
 
+
+def sampling_row(step=0, sample_round=0, sample_index=-1, elapsed_s=0.0, mem_allocated_gb=0.0, mem_reserved_gb=0.0):
+    """Schema for sampling_logs.jsonl: one row per polled tick of a VRAM time
+    series during a sampling round. sample_round = 0-based round counter,
+    sample_index = which sample was rendering at that tick, elapsed_s = offset
+    within the round. Kept separate from the per-step training metrics."""
+    return {
+        "step": step,
+        "sample_round": sample_round,
+        "sample_index": sample_index,
+        "elapsed_s": elapsed_s,
+        "mem_allocated_gb": mem_allocated_gb,
+        "mem_reserved_gb": mem_reserved_gb,
+        "timestamp": datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+    }
+
+
+class SampleMemoryMonitor:
+    """Records a CUDA memory time series during a sampling round. Polls the
+    allocator counters (memory_allocated / memory_reserved) on a daemon thread:
+    no cudaSynchronize, no kernel, no allocation, so it costs no GPU memory and
+    no measurable throughput. set_index() tags each tick with the sample being
+    rendered. Used as a context manager around generation."""
+
+    def __init__(self, sample_round=0, interval_s=1.0):
+        self.sample_round = sample_round
+        self.interval_s = interval_s
+        self.current_index = -1
+        self.samples = []
+        self._stop = threading.Event()
+        self._thread = None
+
+    def set_index(self, index):
+        self.current_index = index
+
+    def __enter__(self):
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                self._thread = threading.Thread(target=self._poll, daemon=True)
+                self._thread.start()
+        except Exception:
+            pass
+        return self
+
+    def __exit__(self, *exc):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    def _poll(self):
+        import contextlib
+        import time
+
+        import torch
+
+        start = time.monotonic()
+        while not self._stop.is_set():
+            with contextlib.suppress(Exception):
+                self.samples.append(
+                    {
+                        "sample_round": self.sample_round,
+                        "sample_index": self.current_index,
+                        "elapsed_s": time.monotonic() - start,
+                        "mem_allocated_gb": torch.cuda.memory_allocated() / 1e9,
+                        "mem_reserved_gb": torch.cuda.memory_reserved() / 1e9,
+                    }
+                )
+            self._stop.wait(self.interval_s)
+
+
 class AIToolkitOxenLogger:
     """
     Logs metrics and saves checkpoints to an Oxen Workspace during AI-toolkit training.
@@ -64,8 +136,11 @@ class AIToolkitOxenLogger:
         self.enabled = True
         self.log_file_name = "training_logs.jsonl"
         self.log_file_path: Optional[str] = None
+        self.sampling_log_file_name = "sampling_logs.jsonl"
+        self.sampling_log_file_path: Optional[str] = None
         self.workspace: Optional[Workspace] = None
         self.df: Optional[DataFrame] = None
+        self.sampling_df: Optional[DataFrame] = None
         self.step_count = 0
 
         if (
@@ -135,7 +210,18 @@ class AIToolkitOxenLogger:
             except Exception as e:
                 print(f"Main process: Warning: Could not add initial dataframe to repo: {e}")
 
-            # Initialize workspace and DataFrame
+            # Sampling metrics get their own DataFrame (different cadence and
+            # columns). Bootstrap it before the workspace so the workspace sees
+            # both files.
+            self.sampling_log_file_path = os.path.join(self.experiment.name, self.sampling_log_file_name)
+            pd.DataFrame([sampling_row()]).to_json(self.sampling_log_file_path, orient="records", lines=True)
+            try:
+                self.experiment.repo.add(self.sampling_log_file_path, dst=os.path.dirname(self.sampling_log_file_path))
+                self.experiment.repo.commit(f"Initial sampling metrics dataframe: {self.sampling_log_file_path}")
+            except Exception as e:
+                print(f"Main process: Warning: Could not add initial sampling dataframe to repo: {e}")
+
+            # Initialize workspace and DataFrames
             self.workspace = Workspace(
                 self.experiment.repo,
                 branch=self.experiment.name,
@@ -144,9 +230,12 @@ class AIToolkitOxenLogger:
             )
 
             self.df = DataFrame(
-                self.workspace, 
-                self.log_file_path, 
+                self.workspace,
+                self.log_file_path,
                 workspace_name=self.fine_tune_id
+            )
+            self.sampling_df = DataFrame(
+                self.workspace, self.sampling_log_file_path, workspace_name=self.fine_tune_id
             )
             print(f"Main process: DataFrame created successfully")
 
@@ -185,6 +274,31 @@ class AIToolkitOxenLogger:
 
         except Exception as e:
             print(f"Main process: Error logging metrics to Oxen: {e}")
+
+    def log_sample_series(self, samples, sample_round, step):
+        """Write a sampling round's VRAM time series to the sampling DataFrame.
+        Runs after generation, off the GPU path; one row per polled tick."""
+        if not self.enabled or not self.is_main_process or self.sampling_df is None or not samples:
+            return
+        try:
+            self.sampling_df = DataFrame(
+                self.workspace, self.sampling_log_file_path, workspace_name=self.fine_tune_id
+            )
+            for s in samples:
+                self.sampling_df.insert_row(
+                    sampling_row(
+                        step=step,
+                        sample_round=sample_round,
+                        sample_index=s["sample_index"],
+                        elapsed_s=s["elapsed_s"],
+                        mem_allocated_gb=s["mem_allocated_gb"],
+                        mem_reserved_gb=s["mem_reserved_gb"],
+                    ),
+                    self.workspace,
+                )
+            print(f"Main process: Logged {len(samples)} sampling memory points for round {sample_round}")
+        except Exception as e:
+            print(f"Main process: Error logging sample memory series to Oxen: {e}")
 
     def is_stopping(self):
         if not self.is_main_process:


### PR DESCRIPTION
ai-toolkit logs VRAM per training step but nothing during sampling, which runs a separate generation pass with its own memory profile. Records a VRAM curve across each sampling round (allocated and reserved over time, tagged with the round and which sample is rendering) in its own metrics table, separate from the per-step training rows. The curve is polled on a side thread that only reads allocator counters, so it adds no GPU memory or slowdown to generation.