### PR TITLE
Standardize agent docs on AGENTS.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md


### PR DESCRIPTION
ai-toolkit already had `AGENTS.md`, so the only change is moving the compatibility symlink from the repo root into `.claude/CLAUDE.md`. That is why the diff is two one-line symlinks.
